### PR TITLE
Add PHP8.0 Support

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "pjordaan/alternate-reflection-extractor",
     "description": "Alternate ReflectionExtractor for symfony/property-info",
     "require": {
-        "php": "^7.1",
+        "php": "^7.1|^8.0",
         "symfony/property-info": "5.*"
     },
     "autoload": {


### PR DESCRIPTION
Since `symfony/property-info` **5.x** is compatible, nothing needs to be altered.